### PR TITLE
Upgrade to .NET 10 and Aspire 13.0.1

### DIFF
--- a/Aspire.AppHost/LinaSys.Aspire.AppHost.csproj
+++ b/Aspire.AppHost/LinaSys.Aspire.AppHost.csproj
@@ -1,17 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.1" />
-
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.0.1">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>183f7ddc-94cf-454c-a474-41544a5cace2</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.Sql" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,7 +23,7 @@
     <!-- Added due to error at .Net 9 -->
     <!-- https://github.com/dotnet/sdk/issues/42651#issuecomment-2499415958 -->
     <ItemGroup Condition=" '$(suppress)' != 'false' ">
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848;https://github.com/advisories/GHSA-x5qj-9vmx-7g6g;https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848;https://github.com/advisories/GHSA-x5qj-9vmx-7g6g;https://github.com/advisories/GHSA-xhfc-gr8f-ffwc;https://github.com/advisories/GHSA-w3q9-fxm7-j8fq" />
     </ItemGroup>
     
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,29 +3,28 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="9.5.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.5.1" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.5.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.0.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.0.1" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.1" />
     <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="9.3.1" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.5.1" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.1" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.5.1" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.0.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
-    <PackageVersion Include="EPPlus" Version="8.2.1" />
+    <PackageVersion Include="EPPlus" Version="8.3.1" />
     <PackageVersion Include="FluentAssertions" Version="8.6.0" />
-    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="MailKit" Version="4.14.1" />
-    <PackageVersion Include="MediatR" Version="13.0.0" />
+    <PackageVersion Include="MediatR" Version="13.1.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,34 +32,34 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.54.0" />
     <PackageVersion Include="Microsoft.SqlServer.DacFx" Version="170.1.61" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
     <PackageVersion Include="MimeKit" Version="4.14.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="Riok.Mapperly" Version="4.1.1" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -1,4 +1,4 @@
-﻿#region usings section
+#region usings section
 using System.Reflection;
 using LinaSys.Auth.Application;
 using LinaSys.Auth.Infrastructure;
@@ -35,7 +35,6 @@ using LinaSys.Web.Infrastructure.Services;
 using LinaSys.Web.Filters;
 using LinaSys.Web.ModelBinders;
 using LinaSys.Web.Services;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using OfficeOpenXml;
 #endregion
 
@@ -80,9 +79,6 @@ builder.Services.AddSingleton<IVersionProvider, VersionProvider>();
 
 // Progress tracking service for bulk operations
 builder.Services.AddSingleton<IProgressTrackingService, ProgressTrackingService>();
-
-// Register IActionContextAccessor for ApplicationUrlService
-builder.Services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
 
 // Register ApplicationUrlService for generating URLs in the application layer
 builder.Services.AddScoped<IApplicationUrlService, ApplicationUrlService>();

--- a/Web/Services/ApplicationUrlService.cs
+++ b/Web/Services/ApplicationUrlService.cs
@@ -2,7 +2,6 @@
 using LinaSys.Shared.Application.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -14,7 +13,7 @@ namespace LinaSys.Web.Services;
 /// </summary>
 public class ApplicationUrlService(
     IUrlHelperFactory urlHelperFactory,
-    IActionContextAccessor actionContextAccessor,
+    IHttpContextAccessor httpContextAccessor,
     IConfiguration configuration) : IApplicationUrlService
 {
 
@@ -171,11 +170,11 @@ public class ApplicationUrlService(
 
     private IUrlHelper GetUrlHelper()
     {
-        var actionContext = actionContextAccessor.ActionContext;
-        if (actionContext is null)
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is null)
         {
             // Fallback for when called outside of HTTP context (e.g., background jobs)
-            var httpContext = new DefaultHttpContext
+            httpContext = new DefaultHttpContext
             {
                 Request =
                 {
@@ -183,9 +182,9 @@ public class ApplicationUrlService(
                     Host = new HostString(GetBaseUrl().Replace("https://", string.Empty).Replace("http://", string.Empty))
                 }
             };
-            actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
         }
 
+        var actionContext = new ActionContext(httpContext, httpContext.GetRouteData(), new ActionDescriptor());
         return urlHelperFactory.GetUrlHelper(actionContext);
     }
 


### PR DESCRIPTION
Fixed build errors after upgrading solution to .NET 10:

  - Remove explicit Aspire.Hosting.AppHost package version (NU1009) Aspire SDK 13.0.1 provides this package implicitly via Central Package Management

  - Suppress Microsoft.Build security vulnerability (NU1903) Added GHSA-w3q9-fxm7-j8fq to NuGetAuditSuppress list

  - Replace obsolete IActionContextAccessor with IHttpContextAccessor (ASPDEPR006) Updated ApplicationUrlService and Program.cs to use the recommended IHttpContextAccessor approach for .NET 10 compatibility